### PR TITLE
fix(record-type-enum-values): values same as keys

### DIFF
--- a/src/models/pycsw/coreEnums.ts
+++ b/src/models/pycsw/coreEnums.ts
@@ -1,5 +1,5 @@
 export enum RecordType {
-  RECORD_RASTER = 'raster',
-  RECORD_3D = '3d',
-  RECORD_ALL = 'all',
+  RECORD_RASTER = 'RECORD_RASTER',
+  RECORD_3D = 'RECORD_3D',
+  RECORD_ALL = 'RECORD_ALL',
 }


### PR DESCRIPTION
RecordType enum values updated to be same as key due to graphQL enum types generation(enum generation should be revisited in generator)