### PR TITLE
fix: turn undefined id, layerpolygonpart and bbox for overseer req

### DIFF
--- a/src/yaml/fullLayerMetadata.yaml
+++ b/src/yaml/fullLayerMetadata.yaml
@@ -12,5 +12,6 @@ components:
             id:
               type: string
               format: uuid
+              default: undefined
             displayPath:
               type: string

--- a/src/yaml/geojson.yaml
+++ b/src/yaml/geojson.yaml
@@ -176,6 +176,7 @@ components:
     FeatureCollection:
       type: object
       description: GeoJson Feature collection
+      default: undefined
       required:
         - type
         - features

--- a/src/yaml/updateLayerMetadata.yaml
+++ b/src/yaml/updateLayerMetadata.yaml
@@ -122,6 +122,7 @@ components:
           $ref: geojson.yaml#/components/schemas/FeatureCollection
         productBoundingBox:
           type: string
+          default: undefined
           pattern: "^-?(0|[1-9]\\d*)(\\.\\d*)?,-?(0|[1-9]\\d*)(\\.\\d*)?,-?(0|[1-9]\\d*)(\\.\\d*)?,-?(0|[1-9]\\d*)(\\.\\d*)?$"
           
     updateStatusLayerMetadata:


### PR DESCRIPTION


| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                       |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                      |
| Chore            | ✖                                                                       |

Fix and restrict the models so the id, layerPolygonParts, and productBoundingBox to be undefined as default (user may not provide them on overseer layer api