### PR TITLE
fix: change format to tileMImeFormat - naming convention

### DIFF
--- a/src/models/layerMetadata/layerMetadata.ts
+++ b/src/models/layerMetadata/layerMetadata.ts
@@ -1097,16 +1097,16 @@ export class LayerMetadata implements ILayerMetadata, IMetadataCommonModel {
   //#endregion
   public transparency: Transparency | undefined = undefined;
 
-  //#region RASTER: format
+  //#region RASTER: tilesMimeFormat
   @pycsw({
     profile: 'mc_raster',
-    xmlElement: 'mc:format',
-    queryableField: 'mc:format',
-    pycswField: 'pycsw:format',
+    xmlElement: 'mc:tilesMimeFormat',
+    queryableField: 'mc:tilesMimeFormat',
+    pycswField: 'pycsw:tilesMimeFormat',
   })
   @catalogDB({
     column: {
-      name: 'format',
+      name: 'tile_mime_format',
       type: 'text',
       nullable: false,
     },

--- a/src/yaml/fullLayerMetadata.yaml
+++ b/src/yaml/fullLayerMetadata.yaml
@@ -26,9 +26,9 @@ components:
               - PNG
               - JPEG
               description: Tile format can be of png or jpeg
-            format:
+            tileMimeFormat:
               type: string
               enum:
               - image/png
               - image/jpeg
-              description: Image format associated with content type
+              description: Image format associated with content type (mime)

--- a/src/yaml/rasterCatalog/insertRequest.yaml
+++ b/src/yaml/rasterCatalog/insertRequest.yaml
@@ -21,7 +21,7 @@ components:
                 - id
                 - displayPath
                 - tileOutputFormat
-                - format
+                - tileMimeFormat
       #due to bug in validator additional properties is not compilable with allof
       #https://github.com/cdimascio/express-openapi-validator/issues/239
       #additionalProperties: false


### PR DESCRIPTION
* pycsw already hold use for name "format" (type). so the new field should include other unique and understandable name.
* the chosen name to represent the image mime type is : "tileMimeFormat"