### PR TITLE
fix: 3d - make id required

### DIFF
--- a/src/yaml/3dCatalog/3dMetadata.yaml
+++ b/src/yaml/3dCatalog/3dMetadata.yaml
@@ -389,6 +389,7 @@ components:
         - productionSystemVer
         - producerName
         - links
+        - id
       properties:
         type:
           type: string
@@ -552,8 +553,9 @@ components:
           type: string
           nullable: true
           description: The keywords of the product
-        identifier:
+        id:
           type: string
+          nullable: false
         links:
           type: array
           minItems: 1


### PR DESCRIPTION
I added the id but I didn't force it to be string. This PR fixes it. Affects only 3D team