### PR TITLE
feat: raster swagger checks

### DIFF
--- a/src/yaml/discreteIngestion/ingestionParams.yaml
+++ b/src/yaml/discreteIngestion/ingestionParams.yaml
@@ -22,4 +22,4 @@ components:
           description: layer sources
           items:
             type: string
-            pattern: ^.+(\.([Tt][Ii][Ff][Ff]?|[Gg][Pp][Kk][Gg]|[Jj][Pp][2Cc]|[Jj]2[Kk]|[Ee][Cc][Ww]))$
+            pattern: ^.+\.[Gg][Pp][Kk][Gg]$

--- a/src/yaml/updateLayerMetadata.yaml
+++ b/src/yaml/updateLayerMetadata.yaml
@@ -29,7 +29,8 @@ components:
             - RECORD_3D
         classification:
           type: string
-          description: Permitted roles 
+          description: Permitted roles
+          pattern: ^[3-6]$
         productId:
           type: string
           description: Layer's external identifier


### PR DESCRIPTION
added validation that classification is between 3-6 and only gpkg file is accepted in FileName field