### PR TITLE
fix: geojson definition

### DIFF
--- a/src/yaml/geojson.yaml
+++ b/src/yaml/geojson.yaml
@@ -180,7 +180,7 @@ components:
         geometries:
           type: array
           items:
-            $ref: "#/components/schemas/GeometryBase"
+            $ref: "#/components/schemas/Geometry"
 
     BBox:
       type: array

--- a/src/yaml/geojson.yaml
+++ b/src/yaml/geojson.yaml
@@ -201,6 +201,10 @@ components:
           type: string
           enum:
             - Feature
+        id:
+          oneOf:
+            - type: number
+            - type: string
         properties:
           type: object
           nullable: true

--- a/src/yaml/geojson.yaml
+++ b/src/yaml/geojson.yaml
@@ -97,6 +97,7 @@ components:
           type: array
           items:
             type: array
+            minItems: 4
             items:
               $ref: "#/components/schemas/Point2D"
   

--- a/src/yaml/geojson.yaml
+++ b/src/yaml/geojson.yaml
@@ -1,12 +1,12 @@
 openapi: "3.0.1"
 info:
-  title: Geojson definitions
+  title: GeoJSON definitions
   version: 1.0.0
 components:
   schemas:
     GeometryBase:
       type: object
-      description: GeoJSon geometry
+      description: GeoJSON geometry
       required:
         - type
       externalDocs:
@@ -21,10 +21,10 @@ components:
             - MultiPoint
             - MultiLineString
             - MultiPolygon
-          description: the geometry type
+          description: geometry type
           
     Geometry:
-      description: GeoJSon geometry
+      description: GeoJSON Geometry
       discriminator:
           propertyName: type
       type: object
@@ -47,7 +47,7 @@ components:
   
     Point:
       type: object
-      description: GeoJSon geometry
+      description: GeoJSON Point
       externalDocs:
         url: http://geojson.org/geojson-spec.html#id2
       required:
@@ -65,7 +65,7 @@ components:
   
     LineString:
       type: object
-      description: GeoJSon geometry
+      description: GeoJSON LineString
       externalDocs:
         url: http://geojson.org/geojson-spec.html#id3
       required:
@@ -86,7 +86,7 @@ components:
   
     Polygon:
       type: object
-      description: GeoJSon geometry
+      description: GeoJSON Polygon
       externalDocs:
         url: http://geojson.org/geojson-spec.html#id4
       required:
@@ -109,7 +109,7 @@ components:
   
     MultiPoint:
       type: object
-      description: GeoJSon geometry
+      description: GeoJSON MultiPoint
       externalDocs:
         url: http://geojson.org/geojson-spec.html#id5
       required:
@@ -129,7 +129,7 @@ components:
   
     MultiLineString:
       type: object
-      description: GeoJSon geometry
+      description: GeoJSON MultiLineString
       externalDocs:
         url: http://geojson.org/geojson-spec.html#id6
       required:
@@ -152,7 +152,7 @@ components:
   
     MultiPolygon:
       type: object
-      description: GeoJSon geometry
+      description: GeoJSON MultiPolygon
       externalDocs:
         url: http://geojson.org/geojson-spec.html#id6
       required:
@@ -177,7 +177,7 @@ components:
   
     GeometryCollection:
       type: object
-      description: GeoJSon geometry collection
+      description: GeoJSON GeometryCollection
       required:
         - type
         - geometries
@@ -226,7 +226,7 @@ components:
 
     FeatureCollection:
       type: object
-      description: GeoJson Feature collection
+      description: GeoJSON Feature collection
       required:
         - type
         - features

--- a/src/yaml/geojson.yaml
+++ b/src/yaml/geojson.yaml
@@ -159,6 +159,7 @@ components:
             type: array
             items:
               type: array
+              minItems: 4
               items:
                 $ref: "#/components/schemas/Point2D"
   

--- a/src/yaml/geojson.yaml
+++ b/src/yaml/geojson.yaml
@@ -136,6 +136,7 @@ components:
           type: array
           items:
             type: array
+            minItems: 2
             items:
               $ref: "#/components/schemas/Point2D"
   

--- a/src/yaml/geojson.yaml
+++ b/src/yaml/geojson.yaml
@@ -60,6 +60,8 @@ components:
             - Point
         coordinates:
           $ref: "#/components/schemas/Point2D"
+        bbox:
+          $ref: "#/components/schemas/BBox"
   
     LineString:
       type: object
@@ -79,6 +81,8 @@ components:
           minItems: 2
           items:
             $ref: "#/components/schemas/Point2D"
+        bbox:
+          $ref: "#/components/schemas/BBox"
   
     Polygon:
       type: object
@@ -100,6 +104,8 @@ components:
             minItems: 4
             items:
               $ref: "#/components/schemas/Point2D"
+        bbox:
+          $ref: "#/components/schemas/BBox"
   
     MultiPoint:
       type: object
@@ -118,6 +124,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Point2D"
+        bbox:
+          $ref: "#/components/schemas/BBox"
   
     MultiLineString:
       type: object
@@ -139,6 +147,8 @@ components:
             minItems: 2
             items:
               $ref: "#/components/schemas/Point2D"
+        bbox:
+          $ref: "#/components/schemas/BBox"
   
     MultiPolygon:
       type: object
@@ -162,6 +172,8 @@ components:
               minItems: 4
               items:
                 $ref: "#/components/schemas/Point2D"
+        bbox:
+          $ref: "#/components/schemas/BBox"
   
     GeometryCollection:
       type: object
@@ -181,6 +193,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Geometry"
+        bbox:
+          $ref: "#/components/schemas/BBox"
 
     BBox:
       type: array

--- a/src/yaml/geojson.yaml
+++ b/src/yaml/geojson.yaml
@@ -76,6 +76,7 @@ components:
             - LineString
         coordinates:
           type: array
+          minItems: 2
           items:
             $ref: "#/components/schemas/Point2D"
   

--- a/src/yaml/geojson.yaml
+++ b/src/yaml/geojson.yaml
@@ -50,84 +50,96 @@ components:
       description: GeoJSon geometry
       externalDocs:
         url: http://geojson.org/geojson-spec.html#id2
-      allOf:
-        - $ref: "#/components/schemas/GeometryBase"
-        - properties:
-            coordinates:
-              $ref: "#/components/schemas/Point2D"
+      properties:
+        type:
+          type: string
+          enum:
+            - Point
+        coordinates:
+          $ref: "#/components/schemas/Point2D"
   
     LineString:
       type: object
       description: GeoJSon geometry
       externalDocs:
         url: http://geojson.org/geojson-spec.html#id3
-      allOf:
-        - $ref: "#/components/schemas/GeometryBase"
-        - properties:
-            coordinates:
-              type: array
-              items:
-                $ref: "#/components/schemas/Point2D"
+      properties:
+        type:
+          type: string
+          enum:
+            - LineString
+        coordinates:
+          type: array
+          items:
+            $ref: "#/components/schemas/Point2D"
   
     Polygon:
       type: object
       description: GeoJSon geometry
       externalDocs:
         url: http://geojson.org/geojson-spec.html#id4
-      allOf:
-        - $ref: "#/components/schemas/GeometryBase"
-        - properties:
-            coordinates:
-              type: array
-              items:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Point2D"
+      properties:
+        type:
+          type: string
+          enum:
+            - Polygon
+        coordinates:
+          type: array
+          items:
+            type: array
+            items:
+              $ref: "#/components/schemas/Point2D"
   
     MultiPoint:
       type: object
       description: GeoJSon geometry
       externalDocs:
         url: http://geojson.org/geojson-spec.html#id5
-      allOf:
-        - $ref: "#/components/schemas/GeometryBase"
-        - properties:
-            coordinates:
-              type: array
-              items:
-                $ref: "#/components/schemas/Point2D"
+      properties:
+        type:
+          type: string
+          enum:
+            - MultiPoint
+        coordinates:
+          type: array
+          items:
+            $ref: "#/components/schemas/Point2D"
   
     MultiLineString:
       type: object
       description: GeoJSon geometry
       externalDocs:
         url: http://geojson.org/geojson-spec.html#id6
-      allOf:
-        - $ref: "#/components/schemas/GeometryBase"
-        - properties:
-            coordinates:
-              type: array
-              items:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Point2D"
+      properties:
+        type:
+          type: string
+          enum:
+            - MultiLineString
+        coordinates:
+          type: array
+          items:
+            type: array
+            items:
+              $ref: "#/components/schemas/Point2D"
   
     MultiPolygon:
       type: object
       description: GeoJSon geometry
       externalDocs:
         url: http://geojson.org/geojson-spec.html#id6
-      allOf:
-        - $ref: "#/components/schemas/GeometryBase"
-        - properties:
-            coordinates:
+      properties:
+        type:
+          type: string
+          enum:
+            - MultiPolygon
+        coordinates:
+          type: array
+          items:
+            type: array
+            items:
               type: array
               items:
-                type: array
-                items:
-                  type: array
-                  items:
-                    $ref: "#/components/schemas/Point2D"
+                $ref: "#/components/schemas/Point2D"
   
     GeometryCollection:
       type: object

--- a/src/yaml/geojson.yaml
+++ b/src/yaml/geojson.yaml
@@ -50,6 +50,9 @@ components:
       description: GeoJSon geometry
       externalDocs:
         url: http://geojson.org/geojson-spec.html#id2
+      required:
+        - type
+        - coordinates
       properties:
         type:
           type: string
@@ -63,6 +66,9 @@ components:
       description: GeoJSon geometry
       externalDocs:
         url: http://geojson.org/geojson-spec.html#id3
+      required:
+        - type
+        - coordinates
       properties:
         type:
           type: string
@@ -78,6 +84,9 @@ components:
       description: GeoJSon geometry
       externalDocs:
         url: http://geojson.org/geojson-spec.html#id4
+      required:
+        - type
+        - coordinates
       properties:
         type:
           type: string
@@ -95,6 +104,9 @@ components:
       description: GeoJSon geometry
       externalDocs:
         url: http://geojson.org/geojson-spec.html#id5
+      required:
+        - type
+        - coordinates
       properties:
         type:
           type: string
@@ -110,6 +122,9 @@ components:
       description: GeoJSon geometry
       externalDocs:
         url: http://geojson.org/geojson-spec.html#id6
+      required:
+        - type
+        - coordinates
       properties:
         type:
           type: string
@@ -127,6 +142,9 @@ components:
       description: GeoJSon geometry
       externalDocs:
         url: http://geojson.org/geojson-spec.html#id6
+      required:
+        - type
+        - coordinates
       properties:
         type:
           type: string

--- a/src/yaml/geojson.yaml
+++ b/src/yaml/geojson.yaml
@@ -22,7 +22,6 @@ components:
             - MultiLineString
             - MultiPolygon
           description: geometry type
-          
     Geometry:
       description: GeoJSON Geometry
       discriminator:
@@ -35,7 +34,6 @@ components:
         - $ref: '#/components/schemas/MultiPoint'
         - $ref: '#/components/schemas/MultiLineString'
         - $ref: '#/components/schemas/MultiPolygon'
-  
     Point2D:
       type: array
       maxItems: 2
@@ -44,7 +42,6 @@ components:
         type: number
         minimum: -180
         maximum: 180
-  
     Point:
       type: object
       description: GeoJSON Point
@@ -62,7 +59,6 @@ components:
           $ref: "#/components/schemas/Point2D"
         bbox:
           $ref: "#/components/schemas/BBox"
-  
     LineString:
       type: object
       description: GeoJSON LineString
@@ -83,7 +79,6 @@ components:
             $ref: "#/components/schemas/Point2D"
         bbox:
           $ref: "#/components/schemas/BBox"
-  
     Polygon:
       type: object
       description: GeoJSON Polygon
@@ -106,7 +101,6 @@ components:
               $ref: "#/components/schemas/Point2D"
         bbox:
           $ref: "#/components/schemas/BBox"
-  
     MultiPoint:
       type: object
       description: GeoJSON MultiPoint
@@ -126,7 +120,6 @@ components:
             $ref: "#/components/schemas/Point2D"
         bbox:
           $ref: "#/components/schemas/BBox"
-  
     MultiLineString:
       type: object
       description: GeoJSON MultiLineString
@@ -149,7 +142,6 @@ components:
               $ref: "#/components/schemas/Point2D"
         bbox:
           $ref: "#/components/schemas/BBox"
-  
     MultiPolygon:
       type: object
       description: GeoJSON MultiPolygon
@@ -174,7 +166,6 @@ components:
                 $ref: "#/components/schemas/Point2D"
         bbox:
           $ref: "#/components/schemas/BBox"
-  
     GeometryCollection:
       type: object
       description: GeoJSON GeometryCollection
@@ -195,13 +186,11 @@ components:
             $ref: "#/components/schemas/Geometry"
         bbox:
           $ref: "#/components/schemas/BBox"
-
     BBox:
       type: array
       minItems: 4
       items:
         type: number
-    
     Feature:
       required:
         - type
@@ -210,7 +199,7 @@ components:
       properties:
         type:
           type: string
-          enum: 
+          enum:
             - Feature
         properties:
           type: object


### PR DESCRIPTION
made geojson openapi definition to closely match geojson json schema definition

other repos reference `GeometryBase` altough it's undefined by GeoJSON spec. it is currently left in place to allow other repos to upgrade seamlessly. we might consider marking it as deprecated