### PR TITLE
fix: changed horizontalAccuracyCE90 to numeric (MAPCO-5791)

### DIFF
--- a/src/models/layerMetadata/layerMetadata.ts
+++ b/src/models/layerMetadata/layerMetadata.ts
@@ -431,7 +431,7 @@ export class LayerMetadata implements ILayerMetadata, IMetadataCommonModel {
   @catalogDB({
     column: {
       name: 'max_horizontal_accuracy_ce_90',
-      type: 'real',
+      type: 'numeric',
     },
   })
   @tsTypes({
@@ -474,7 +474,7 @@ export class LayerMetadata implements ILayerMetadata, IMetadataCommonModel {
   @catalogDB({
     column: {
       name: 'min_horizontal_accuracy_ce_90',
-      type: 'real',
+      type: 'numeric',
     },
   })
   @tsTypes({

--- a/src/models/polygonParts/polygonPartRecord.ts
+++ b/src/models/polygonParts/polygonPartRecord.ts
@@ -277,7 +277,7 @@ export class PolygonPartRecord implements IPolygonPart, IOrmCatalog {
   @catalogDB({
     column: {
       name: camelCaseToSnakeCase('horizontalAccuracyCE90'),
-      type: 'real',
+      type: 'numeric',
       nullable: false,
     },
   })


### PR DESCRIPTION
To make sure Typeorm doesn't cast the type to double precision in constraints