### PR TITLE
fix: mimeType mapping in raster pycsw decorator(MAPCO-7081)

### DIFF
--- a/src/models/layerMetadata/layerRASTERMetadata.ts
+++ b/src/models/layerMetadata/layerRASTERMetadata.ts
@@ -1098,9 +1098,9 @@ export class LayerMetadata implements RasterLayerMetadata {
   //#region RASTER: tilesMimeFormat
   @pycsw({
     profile: 'mc_raster',
-    xmlElement: 'mc:tilesMimeFormat',
-    queryableField: 'mc:tilesMimeFormat',
-    pycswField: 'pycsw:tilesMimeFormat',
+    xmlElement: 'mc:mimeType',
+    queryableField: 'mc:mimeType',
+    pycswField: 'pycsw:MimeType',
   })
   @catalogDB({
     column: {


### PR DESCRIPTION
To avoid breaking changes in pycsw and raster catalog - the mapping on the decorator was modified to represent the real mapping of the fields.