### PR TITLE
fix(deps): upgrade @map-colonies/raster-shared to ^8.3.0 (MAPCO-11282)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "19.2.2",
       "license": "ISC",
       "dependencies": {
-        "@map-colonies/raster-shared": "8.3.0-alpha.0",
+        "@map-colonies/raster-shared": "^8.3.0",
         "@types/geojson": "^7946.0.7",
         "change-case-all": "^2.1.0",
         "reflect-metadata": "^0.1.13",
@@ -1399,9 +1399,9 @@
       "dev": true
     },
     "node_modules/@map-colonies/raster-shared": {
-      "version": "8.3.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-8.3.0-alpha.0.tgz",
-      "integrity": "sha512-xcleqPf+KSOObCqHuKm1nng7WQRAZ0JrX12qe1U8pX8iijZ7pS7QMrHnPM7DFU5cxMoxkgnRC8hVzd1SMLiErQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-8.3.0.tgz",
+      "integrity": "sha512-5faR0iBC9Dpxm7Z8fY+3d+5oolHqVk/urXeOq3nHuIEMOvwRT2TrTr9fmt6TK8DaCjyQXBeEU1nijvuPLHmrEw==",
       "license": "ISC",
       "dependencies": {
         "@map-colonies/mc-priority-queue": "^9.1.0",
@@ -14014,9 +14014,9 @@
       "dev": true
     },
     "@map-colonies/raster-shared": {
-      "version": "8.3.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-8.3.0-alpha.0.tgz",
-      "integrity": "sha512-xcleqPf+KSOObCqHuKm1nng7WQRAZ0JrX12qe1U8pX8iijZ7pS7QMrHnPM7DFU5cxMoxkgnRC8hVzd1SMLiErQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-8.3.0.tgz",
+      "integrity": "sha512-5faR0iBC9Dpxm7Z8fY+3d+5oolHqVk/urXeOq3nHuIEMOvwRT2TrTr9fmt6TK8DaCjyQXBeEU1nijvuPLHmrEw==",
       "requires": {
         "@map-colonies/mc-priority-queue": "^9.1.0",
         "@map-colonies/types": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test:integration": "jest --config=./tests/configurations/integration/jest.config.js"
   },
   "dependencies": {
-    "@map-colonies/raster-shared": "8.3.0-alpha.0",
+    "@map-colonies/raster-shared": "^8.3.0",
     "@types/geojson": "^7946.0.7",
     "change-case-all": "^2.1.0",
     "reflect-metadata": "^0.1.13",


### PR DESCRIPTION
## Summary
MAPCO-11282 — upgrade `@map-colonies/raster-shared` to the official **v8.3.0** release.

`8.3.0-alpha.0` → `^8.3.0`

## ⚠️ Wider reach than the other five
This publishes as **`@map-colonies/mc-model-types`**, which **~30 repos depend on** — not just raster. Merging triggers a patch release that propagates org-wide. Worth timing deliberately.

## Tests

| | Baseline | After bump |
|---|---|---|
| Suite 1 | 18 passed | 18 passed |
| Suite 2 | 1 passed | 1 passed |

Run on Node 24 to match CI. Baseline captured on unmodified `origin/master` first.

## Note
Depends on #297 (`.nvmrc` v12 → v24) for local review — `nvm use && npm ci` currently fails on master without it.
